### PR TITLE
Renamed global function wpfluent_eql() to fluentconnector_eql() 

### DIFF
--- a/boot/globals_dev.php
+++ b/boot/globals_dev.php
@@ -4,7 +4,7 @@
  * Enable Query Log
  */
 if (!function_exists('fluentconnector_eql')) {
-    function wpfluent_eql()
+    function fluentconnector_eql()
     {
         defined('SAVEQUERIES') || define('SAVEQUERIES', true);
     }


### PR DESCRIPTION
Fix: Renamed global function wpfluent_eql() to fluentconnector_eql() to prevent fatal error caused by function name conflict